### PR TITLE
Wolfram Alpha Short Answers

### DIFF
--- a/src/CorsInfo.tsx
+++ b/src/CorsInfo.tsx
@@ -1,0 +1,37 @@
+import { Button, Link, Typography } from "@mui/material";
+import { useState } from "react";
+import { Stack } from "@mui/system";
+import AltRouteIcon from "@mui/icons-material/AltRoute";
+import { proxyUrl } from "./tools/base/Cors";
+import { corsInfoButtonStyle, corsLinkStyle } from "./MuiStyles";
+
+export function CorsInfo() {
+	const [hover, setHover] = useState(false);
+	return (
+		<Button
+			sx={corsInfoButtonStyle}
+			onClick={() => {
+				window.open(proxyUrl(""), "_blank");
+			}}
+			onMouseEnter={() => {
+				setHover(true);
+			}}
+			onMouseLeave={() => {
+				setHover(false);
+			}}
+		>
+			<Stack spacing={1} alignItems={"center"} direction={"row"}>
+				<Stack>
+					<Typography variant="subtitle2">uses CORS proxy</Typography>
+					<Link
+						variant="caption"
+						sx={{ ...corsLinkStyle, height: hover ? "20px" : "0px" }}
+					>
+						{proxyUrl("")}
+					</Link>
+				</Stack>
+				<AltRouteIcon></AltRouteIcon>
+			</Stack>
+		</Button>
+	);
+}

--- a/src/MuiStyles.tsx
+++ b/src/MuiStyles.tsx
@@ -111,3 +111,15 @@ export const toolSetupDrawerPaperProps = {
 		backgroundColor: "#00000000",
 	},
 };
+
+export const corsInfoButtonStyle = {
+	marginLeft: "auto",
+	color: "black",
+	textAlign: "left",
+	height: "60px",
+};
+
+export const corsLinkStyle = {
+	overflow: "hidden",
+	transition: "all 200ms",
+};

--- a/src/ToolInfo.tsx
+++ b/src/ToolInfo.tsx
@@ -11,6 +11,7 @@ import {
 	toolInfoBodyStyle,
 	toolInfoExamplesStyle,
 } from "./MuiStyles";
+import { CorsInfo } from "./CorsInfo";
 
 interface InfoProps {
 	tool: Tool;
@@ -69,8 +70,9 @@ export function ToolInfo(props: InfoProps) {
 						{props.tool.getHumanDescription()}
 					</Typography>
 				</Stack>
+				{props.tool.usesCorsProxy() && <CorsInfo></CorsInfo>}
 				<ThemedToggle
-					sx={{ marginLeft: "auto" }}
+					sx={{ marginLeft: props.tool.usesCorsProxy() ? "20px" : "auto" }}
 					value="check"
 					selected={active}
 					onChange={() => {

--- a/src/tools/WolframAlpha.tsx
+++ b/src/tools/WolframAlpha.tsx
@@ -1,0 +1,93 @@
+import { Tool } from "./base/Tool";
+import { ToolParam } from "./base/ToolParam";
+import FunctionsIcon from "@mui/icons-material/Functions";
+import { ReactElement } from "react";
+import { proxyUrl } from "./base/Cors";
+
+const wolfram_url = "https://api.wolframalpha.com/v1/result?appid=API_KEY&i=";
+
+export class WolframAlpha extends Tool {
+	wolframApiKey = "";
+
+	getExpectedParams(): ToolParam[] {
+		return [
+			{
+				paramName: "wolframApiKey",
+				humanName: "Wolfram Alpha API Key",
+				instructions: `Create a Wolfram Alpha app at the link below,
+                then copy the generated AppID.`,
+				link: "https://developer.wolframalpha.com/portal/myapps/index.html",
+				exampleValue: "WRG3GS-T2SRGVLT42",
+			},
+		];
+	}
+
+	setParams(params: { [key: string]: string }) {
+		this.wolframApiKey = params.wolframApiKey ?? this.wolframApiKey;
+		if (this.wolframApiKey.length != 17)
+			return new Error("No valid Wolfram API Key set.");
+	}
+
+	getName(): string {
+		return "WOLFRAM";
+	}
+
+	getUniqueHumanName(): string {
+		return "Wolfram Alpha";
+	}
+
+	getHumanDescription(): string {
+		return "Providing access to the Wolfram Alpha Short Answers API.";
+	}
+
+	getDefinition(): string {
+		return "This queries Wolfram Alpha for an answer.";
+	}
+
+	getExamplePrompt(): string {
+		return "What is the second derivative of sin(2x)?";
+	}
+
+	getExampleCompletion(): string {
+		return "[WOLFRAM(second derivative of sin(2x)) -> -4 Sin[2x]] The second derivative of sin(2x) is -4 Sin[2x]";
+	}
+
+	getExampleMultiPrompt(): string {
+		return "What are the colors of the thai flag and what is the hex code of the first one?";
+	}
+
+	getExampleMultiCompletion(): string {
+		return "[WOLFRAM(colors of thailand flag) -> five horizontal bands of red (top), white, blue (double width), white, and red] The colors of the thai flag are red, white and blue. [WOLFRAM(hex code of blue) -> #0000FF] The hex code of the first one, blue, is #0000FF.";
+	}
+
+	getExampleMultiDependencies(): Array<string> {
+		return [];
+	}
+
+	getIcon(): ReactElement {
+		return <FunctionsIcon />;
+	}
+
+	usesCorsProxy(): boolean {
+		return true;
+	}
+
+	async useTool(query: string) {
+		//Fetch result from Wolfram Alpha API
+		let url = proxyUrl(
+			wolfram_url.replace("API_KEY", this.wolframApiKey) + encodeURI(query)
+		);
+		await fetch(url, {
+			method: "GET",
+		})
+			.then((response) => response.text())
+			.then((text) => {
+				console.log(text);
+				this.reportResult(text);
+			})
+			.catch((error) => {
+				this.reportError(error);
+				console.error(error);
+			});
+	}
+}

--- a/src/tools/base/AllTools.tsx
+++ b/src/tools/base/AllTools.tsx
@@ -2,8 +2,9 @@ import { Google } from "../Google";
 import { MathJS } from "../MathJS";
 import { Now } from "../Now";
 import { SpotifyPlaylist } from "../SpotifyPlaylist";
+import { WolframAlpha } from "../WolframAlpha";
 import { Tool } from "./Tool";
 
 export const allTools: Array<
 	new (onResult?: Function, onError?: Function) => Tool
-> = [Google, MathJS, Now, SpotifyPlaylist];
+> = [Google, MathJS, Now, WolframAlpha, SpotifyPlaylist];

--- a/src/tools/base/Cors.tsx
+++ b/src/tools/base/Cors.tsx
@@ -1,0 +1,4 @@
+//Default cors proxy that may be necessary for some APIs
+export function proxyUrl(url: string) {
+	return "https://corsproxy.io/?" + url;
+}

--- a/src/tools/base/Tool.tsx
+++ b/src/tools/base/Tool.tsx
@@ -85,10 +85,16 @@ export abstract class Tool {
 	getExampleMultiDependencies(): Array<string> {
 		return [];
 	}
-
 	//Tools must return an icon as a ReactElement
 	//Preferably these are Material-UI icons
 	abstract getIcon(): ReactElement;
+
+	//For the sake of transparency, tools must override this method and return true if they utilize proxyUrl().
+	//Some users may not be comfortable routing requests through proxies. A badge will be shown
+	//for each tool returning true.
+	usesCorsProxy(): boolean {
+		return false;
+	}
 
 	//Tools may provide an array of string params the must be passed to them
 	//after construction, such as API keys. This may be left empty if none are needed.


### PR DESCRIPTION
- Adds [Wolfram Alpha Short Answers](https://products.wolframalpha.com/short-answers-api/documentation) tool
- Adds support for CORS proxy (currently https://corsproxy.io)
  - Transparently show when a tool is making use of this, in case users do not wish to proxy their outgoing requests