### PR TITLE
Support window.ai

### DIFF
--- a/src/Constants.tsx
+++ b/src/Constants.tsx
@@ -5,6 +5,7 @@ export const defaultTools: Array<string> = ["Google Search", "Math JS", "Now"];
 export const prompt_template = `You are an AI assistant with several tools available to you. The tools are the following:
 TOOL_DEFINITIONS
 DO NOT USE TOOLS WITHIN TOOLS! KEEP ALL TOOL CALLS SEPARATE FROM EACH OTHER!
+Make sure to continue the given prompt where it was left off. After a tool was used, make sure to continue the sentence as it was BEFORE the tool call.
 
 TOOL_EXAMPLES
 User: USER_INPUT

--- a/src/Cookies.tsx
+++ b/src/Cookies.tsx
@@ -65,3 +65,17 @@ export function removeActiveTool(toolName: string) {
 		path: "/",
 	});
 }
+
+export function getWindowAiActive() {
+	//Get window.ai setting
+	const cookies = new Cookies();
+	return cookies.get("windowAiActive") == "true" ?? false;
+}
+
+export function storeWindowAiActive(isActive: boolean) {
+	//Save window.ai setting
+	const cookies = new Cookies();
+	cookies.set("windowAiActive", isActive, {
+		path: "/",
+	});
+}

--- a/src/ModelListItem.tsx
+++ b/src/ModelListItem.tsx
@@ -1,0 +1,48 @@
+import {
+	ListItem,
+	ListItemButton,
+	ListItemIcon,
+	ListItemText,
+} from "@mui/material";
+import { Tool } from "./tools/base/Tool";
+import { primaryColor } from "./Constants";
+import CheckIcon from "@mui/icons-material/Check";
+import { isToolActive } from "./Cookies";
+import DeveloperBoardIcon from "@mui/icons-material/DeveloperBoard";
+
+interface ListItemProps {
+	name: string;
+	index: number;
+	activeItem: number;
+	setActiveItem: Function;
+	isActive: Function;
+}
+
+export function ModelListItem(props: ListItemProps) {
+	return (
+		<ListItem key={props.index} disablePadding>
+			<ListItemButton
+				onClick={() => {
+					props.setActiveItem(props.index);
+				}}
+			>
+				<ListItemIcon
+					sx={{ color: props.activeItem == props.index ? primaryColor : "" }}
+				>
+					{<DeveloperBoardIcon />}
+				</ListItemIcon>
+				<ListItemText
+					sx={{ color: props.activeItem == props.index ? primaryColor : "" }}
+					primary={props.name}
+				/>
+				{props.isActive() && (
+					<ListItemIcon
+						sx={{ color: props.activeItem == props.index ? primaryColor : "" }}
+					>
+						<CheckIcon />
+					</ListItemIcon>
+				)}
+			</ListItemButton>
+		</ListItem>
+	);
+}

--- a/src/OpenAi.tsx
+++ b/src/OpenAi.tsx
@@ -1,0 +1,66 @@
+export async function getOpenAiCompletion(
+	final_prompt: string,
+	getToolParam: Function,
+	handleToken: Function,
+	addError: Function
+) {
+	//Stream completion from OpenAI);
+	var es = await fetch("https://api.openai.com/v1/completions", {
+		headers: {
+			"Content-Type": "application/json",
+			Authorization: "Bearer " + getToolParam("Global", "openaiApiKey"),
+		},
+		method: "POST",
+		body: JSON.stringify({
+			model: "text-davinci-003",
+			prompt: final_prompt,
+			temperature: 0.7,
+			max_tokens: 500,
+			stream: true,
+		}),
+	});
+	const reader = es.body?.pipeThrough(new TextDecoderStream()).getReader();
+	if (!reader) return;
+
+	//Stream completion either until a tool was used or the completion has ended
+	let toolUsed = false;
+	while (!toolUsed) {
+		const res = await reader?.read();
+		toolUsed = await readCompletionStream(res, handleToken, addError);
+		if (res?.done) break;
+	}
+}
+
+async function readCompletionStream(
+	res: ReadableStreamReadResult<string>,
+	handleToken: Function,
+	addError: Function
+) {
+	//Parse OpenAI response
+	//Multiple JSON responses may be received in one execution of reader.read()
+	//We therefore sanitize the raw response and then split on newlines
+	const raw_json = res?.value?.replaceAll("data:", "").trim() ?? "";
+	const split_json = raw_json.split("\n");
+	let toolUsed = false;
+	//Attempt to parse each received JSON object
+	split_json.every((json_string) => {
+		json_string = json_string.trim();
+		if (json_string.length > 0) {
+			try {
+				const json = JSON.parse(json_string);
+				//Get completion token(s) received
+				let token: string = json.choices[0].text;
+				toolUsed = handleToken(token);
+			} catch (ex) {
+				//If exception is not caused by OpenAI [DONE] payload, throw error
+				if (json_string.indexOf("[DONE]") == -1) {
+					addError();
+					console.error(ex);
+				}
+			}
+		}
+		//Break out of every() if tool was used
+		return !toolUsed;
+	});
+	return toolUsed;
+}

--- a/src/ToolSetup.tsx
+++ b/src/ToolSetup.tsx
@@ -19,6 +19,9 @@ import {
 	toolSetupDrawerPaperProps,
 	toolSetupDrawerStyle,
 } from "./MuiStyles";
+import { ModelListItem } from "./ModelListItem";
+import { WindowAiInfo } from "./WindowAiInfo";
+import { getWindowAiActive } from "./Cookies";
 
 interface SetupProps {
 	tools: Array<Tool>;
@@ -28,6 +31,7 @@ interface SetupProps {
 	setToolResult: Function;
 	setToolError: Function;
 	applyToolParams: Function;
+	updateWindowAiActive: Function;
 }
 
 export function ToolSetup(props: SetupProps) {
@@ -39,7 +43,11 @@ export function ToolSetup(props: SetupProps) {
 		props.updateActiveTools(tool, isActive);
 	}
 
-	const toolInstance = new allTools[activeItem](
+	function updateWindowAiActive(isActive: boolean) {
+		props.updateWindowAiActive(isActive);
+	}
+
+	const toolInstance = new allTools[Math.max(0, activeItem - 1)](
 		props.setToolResult,
 		props.setToolError
 	);
@@ -68,20 +76,36 @@ export function ToolSetup(props: SetupProps) {
 							{availableTools.map((t, index) => (
 								<ToolListItem
 									tool={new t()}
-									index={index}
+									index={index + 1}
 									activeItem={activeItem}
 									setActiveItem={setActiveItem}
 								></ToolListItem>
 							))}
+							<Divider />
+							<ModelListItem
+								name={"window.ai"}
+								index={0}
+								activeItem={activeItem}
+								setActiveItem={setActiveItem}
+								isActive={getWindowAiActive}
+							></ModelListItem>
 						</List>
 					</div>
 				</Drawer>
 			</Box>
-			<ToolInfo
-				updateActive={updateActive}
-				tool={toolInstance}
-				{...props}
-			></ToolInfo>
+			{activeItem === 0 ? (
+				<WindowAiInfo
+					updateActive={updateWindowAiActive}
+					isActive={getWindowAiActive}
+					{...props}
+				></WindowAiInfo>
+			) : (
+				<ToolInfo
+					updateActive={updateActive}
+					tool={toolInstance}
+					{...props}
+				></ToolInfo>
+			)}
 		</Box>
 	);
 }

--- a/src/WindowAi.tsx
+++ b/src/WindowAi.tsx
@@ -1,0 +1,101 @@
+type Output = {
+	text?: string;
+	message?: ChatMessage;
+};
+
+type ChatMessage = {
+	role: Role;
+	content: string;
+};
+
+type Role = "system" | "user" | "assistant";
+
+interface CompletionOptions {
+	// If specified, partial updates will be streamed to this handler as they become available,
+	// and only the first partial update will be returned by the Promise.
+	onStreamResult?: (result: Output | null, error: string | null) => unknown;
+	// What sampling temperature to use, between 0 and 2. Higher values like 0.8 will
+	// make the output more random, while lower values like 0.2 will make it more focused and deterministic.
+	// Different models have different defaults.
+	temperature?: number;
+	// How many chat completion choices to generate for each input message. Defaults to 1.
+	// The maximum number of tokens to generate in the chat completion. Defaults to infinity, but the
+	// total length of input tokens and generated tokens is limited by the model's context length.
+	maxTokens?: number;
+	// Sequences where the API will stop generating further tokens.
+	stopSequences?: string[];
+	// Identifier of the model to use. Defaults to the user's current model, but can be overridden here.
+	model?: string;
+}
+
+export async function getWindowAICompletion(
+	final_prompt: string,
+	handleToken: Function,
+	addError: Function
+) {
+	//Request completion from WindowAI model
+	var toolUsed = false;
+	const completionOptions: CompletionOptions = {
+		temperature: 0.7,
+		maxTokens: 100,
+		onStreamResult: (result: Output | null, error: string | null) => {
+			//On result, cancel if tool was used
+			if (toolUsed) return;
+			//Otherwise, handle token
+			if (result) {
+				let token = "";
+				if (result.message) {
+					token = result.message.content;
+				} else if (result.text) {
+					token = result.text;
+				}
+				toolUsed = handleToken(token);
+			} else if (error) {
+				addError();
+				console.error(error);
+			}
+		},
+	};
+	await (window as any).ai.getCurrentModel();
+	await (window as any).ai.getCompletion(
+		{
+			messages: parsePromptAsChat(final_prompt),
+		},
+		completionOptions
+	);
+}
+
+function parsePromptAsChat(prompt: string): ChatMessage[] {
+	const messages: ChatMessage[] = [];
+	//Regex finding occurences of "User: ", "Assistant: " and "]"
+	const regex = /((User|Assistant):|])/g;
+	//Split prompt by regex
+	const splitPrompt = prompt.split(regex);
+	//Add first split as system message
+	messages.push({
+		role: "system",
+		content: splitPrompt[0],
+	});
+	//Iterate over split prompt, track current role and add messages
+	let lastRole: Role = "system";
+	splitPrompt.forEach((element, index) => {
+		if (element && index > 0) {
+			if (element.includes("User")) {
+				lastRole = "user";
+			} else if (element.includes("Assistant")) {
+				lastRole = "assistant";
+			} else if (element != "]") {
+				let x = 0;
+				//Add trailing "]" to tool calls
+				if (element.includes("->")) {
+					element += "]";
+				}
+				messages.push({
+					role: lastRole,
+					content: element,
+				});
+			}
+		}
+	});
+	return messages;
+}

--- a/src/WindowAiInfo.tsx
+++ b/src/WindowAiInfo.tsx
@@ -1,0 +1,93 @@
+import {
+	Box,
+	Divider,
+	Link,
+	styled,
+	ToggleButton,
+	Typography,
+} from "@mui/material";
+import { useEffect, useRef, useState } from "react";
+import { Stack } from "@mui/system";
+import { Tool } from "./tools/base/Tool";
+import { primaryColor } from "./Constants";
+import CheckIcon from "@mui/icons-material/Check";
+import { ParamsSetup } from "./ParamsSetup";
+import { addActiveTool, isToolActive, removeActiveTool } from "./Cookies";
+import {
+	toolInfoContainerStyle,
+	toolInfoBodyStyle,
+	toolInfoExamplesStyle,
+} from "./MuiStyles";
+import { CorsInfo } from "./CorsInfo";
+
+interface InfoProps {
+	showErrorToast: Function;
+	updateActive: Function;
+	applyToolParams: Function;
+	isActive: Function;
+}
+
+const ThemedToggle = styled(ToggleButton)({
+	"&.Mui-selected, &.Mui-selected:hover": {
+		color: "white",
+		backgroundColor: primaryColor,
+	},
+});
+
+export function WindowAiInfo(props: InfoProps) {
+	const [active, setActive] = useState(false);
+
+	useEffect(() => {
+		setActive(props.isActive());
+	});
+
+	function updateActive(isActive: boolean) {
+		setActive(isActive);
+		props.updateActive(isActive);
+	}
+
+	return (
+		<Box key="Models" component="main" sx={toolInfoContainerStyle}>
+			<Box sx={toolInfoBodyStyle}>
+				<Stack>
+					<Typography variant="h4">window.ai</Typography>
+					<Typography variant="subtitle1">
+						Enable this to use the{" "}
+						<Link href="https://windowai.io" target={"_blank"}>
+							window.ai
+						</Link>{" "}
+						extension.
+					</Typography>
+				</Stack>
+				<ThemedToggle
+					sx={{ marginLeft: "auto" }}
+					value="check"
+					selected={active}
+					onChange={() => {
+						updateActive(!active);
+					}}
+				>
+					<CheckIcon />
+				</ThemedToggle>
+			</Box>
+			<Divider>About</Divider>
+			<Stack sx={toolInfoExamplesStyle}>
+				<Typography variant="subtitle1">How does window.ai work?</Typography>
+				<Typography color={"#00000099"} variant="subtitle1">
+					Navigate to{" "}
+					<Link href="https://windowai.io" target={"_blank"}>
+						window.ai
+					</Link>{" "}
+					and set up the browser extension. window.ai will store your API keys
+					for use across different sites, and allow you to choose between any
+					supported model (including local ones!). Simply select your preferred
+					one in the extension settings, and toolformer-zero will be using it.
+				</Typography>
+				<Typography color={"#00000099"} variant="subtitle1">
+					Make sure window.ai is enabled after installing by ticking the
+					checkbox above!
+				</Typography>
+			</Stack>
+		</Box>
+	);
+}


### PR DESCRIPTION
- Add support for [window.ai](https://windowai.io) browser extension
  - Can be enabled in settings menu
  - If extension is installed, will use model chosen by user in extension settings
- Add window.ai setting to settings menu
- Add support for chat-based models via window.ai completions
  - For easy compatibility with legacy logic, we parse the raw prompt as it would be sent to davinci and split it into chat messages before each request
  - In order to preserve the natural language flow of toolformer-style tool usage, two `assistant`-type messages are chained after one another, split after the tool use. Due to examples of this being included by means of the tool-examples injected into the base prompt, models are quite good at following this structure and continuing left off sentences rather than starting a new one.
  - For further improvements, a small explanatory text was added to the system /base prompt