### PR TITLE
Setup Changes

### DIFF
--- a/src/AltInfo.tsx
+++ b/src/AltInfo.tsx
@@ -1,0 +1,51 @@
+import { Button, Link, Typography } from "@mui/material";
+import { ReactElement, useState } from "react";
+import { Stack } from "@mui/system";
+import {
+	alitInfoTitleStyle,
+	altInfoButtonStyle,
+	corsLinkStyle,
+} from "./MuiStyles";
+
+interface Props {
+	text: string;
+	link: string;
+	icon: ReactElement;
+}
+
+export function AltInfo(props: Props) {
+	const [hover, setHover] = useState(false);
+	return (
+		<Button
+			sx={altInfoButtonStyle}
+			onClick={() => {
+				window.open(props.link, "_blank");
+			}}
+			onMouseEnter={() => {
+				setHover(true);
+			}}
+			onMouseLeave={() => {
+				setHover(false);
+			}}
+		>
+			<Stack spacing={5} alignItems={"center"} direction={"row"}>
+				{props.icon}
+				<Stack>
+					<Typography
+						variant="subtitle2"
+						whiteSpace={"pre-line"}
+						sx={alitInfoTitleStyle}
+					>
+						{props.text}
+					</Typography>
+					<Link
+						variant="caption"
+						sx={{ ...corsLinkStyle, height: hover ? "20px" : "0px" }}
+					>
+						{props.link}
+					</Link>
+				</Stack>
+			</Stack>
+		</Button>
+	);
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -194,7 +194,7 @@ function App() {
 
 	async function getCompletion(final_prompt: string) {
 		rawCompletion.current = final_prompt;
-		if (windowAiActive) {
+		if (getWindowAiActive()) {
 			getWindowAICompletion(
 				final_prompt,
 				(token: string) => handleToken(token),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,10 +56,12 @@ function App() {
 	}, []);
 
 	function completeSetup(openaiApiKey: string, wasUserInput: boolean) {
-		setWindowAiActive(getWindowAiActive());
+		setWindowAiActive(initWindowAi());
 		initializeActiveTools();
 
-		if (openaiApiKey?.length != 51) return false;
+		//Conditionals required to skip setup
+		if (getToolParam("Google Search", "googleAppId").length == 0) return false;
+		if (openaiApiKey?.length != 51 && !getWindowAiActive()) return false;
 		setSetupCompleted(true);
 		return true;
 	}
@@ -73,6 +75,13 @@ function App() {
 			}, 5000)
 		);
 		return false;
+	}
+
+	function initWindowAi() {
+		if ((window as any).ai) {
+			storeWindowAiActive(true, false);
+		}
+		return getWindowAiActive();
 	}
 
 	function getCookies() {
@@ -126,6 +135,7 @@ function App() {
 	}
 
 	function updateWindowAiActive(isActive: boolean) {
+		if (!getToolParam("Global", "openaiApiKey") && !isActive) return;
 		storeWindowAiActive(isActive);
 		setWindowAiActive(isActive);
 	}

--- a/src/Cookies.tsx
+++ b/src/Cookies.tsx
@@ -69,12 +69,15 @@ export function removeActiveTool(toolName: string) {
 export function getWindowAiActive() {
 	//Get window.ai setting
 	const cookies = new Cookies();
-	return cookies.get("windowAiActive") == "true" ?? false;
+	return cookies.get("windowAiActive") == "true" && (window as any).ai;
 }
 
-export function storeWindowAiActive(isActive: boolean) {
+export function storeWindowAiActive(isActive: boolean, force = true) {
 	//Save window.ai setting
+	//Only save if force is true or setting is not yet defined
 	const cookies = new Cookies();
+	if (cookies.get("windowAiActive") != undefined && !force) return;
+	isActive = (window as any).ai ? isActive : false;
 	cookies.set("windowAiActive", isActive, {
 		path: "/",
 	});

--- a/src/Cookies.tsx
+++ b/src/Cookies.tsx
@@ -69,7 +69,9 @@ export function removeActiveTool(toolName: string) {
 export function getWindowAiActive() {
 	//Get window.ai setting
 	const cookies = new Cookies();
-	return cookies.get("windowAiActive") == "true" && (window as any).ai;
+	return (
+		cookies.get("windowAiActive") == "true" && (window as any).ai != undefined
+	);
 }
 
 export function storeWindowAiActive(isActive: boolean, force = true) {

--- a/src/ModelListItem.tsx
+++ b/src/ModelListItem.tsx
@@ -4,10 +4,8 @@ import {
 	ListItemIcon,
 	ListItemText,
 } from "@mui/material";
-import { Tool } from "./tools/base/Tool";
 import { primaryColor } from "./Constants";
 import CheckIcon from "@mui/icons-material/Check";
-import { isToolActive } from "./Cookies";
 import DeveloperBoardIcon from "@mui/icons-material/DeveloperBoard";
 
 interface ListItemProps {

--- a/src/MuiStyles.tsx
+++ b/src/MuiStyles.tsx
@@ -123,3 +123,12 @@ export const corsLinkStyle = {
 	overflow: "hidden",
 	transition: "all 200ms",
 };
+
+export const altInfoButtonStyle = {
+	color: primaryColor,
+	textAlign: "left",
+	height: "100px",
+	justifyContent: "flex-start",
+};
+
+export const alitInfoTitleStyle = { maxWidth: "420px", color: "#00000099" };

--- a/src/ParamsSetup.tsx
+++ b/src/ParamsSetup.tsx
@@ -13,7 +13,7 @@ import {
 } from "@mui/material";
 import { paramsTextFieldStyle, setupCardStyle } from "./MuiStyles";
 import { Tool } from "./tools/base/Tool";
-import { getToolParam, updateToolParams } from "./Cookies";
+import { getToolParam, getWindowAiActive, updateToolParams } from "./Cookies";
 import { primaryColor } from "./Constants";
 import { useState } from "react";
 
@@ -119,13 +119,15 @@ export function ParamsSetup(props: SetupProps) {
 		return toolParams;
 	}
 
+	function showOpenAiSetup() {
+		return props.completeSetup && !(window as any).ai;
+	}
+
 	function getSteps() {
 		//Get all required steps
 		//This can be default steps on initial setup
 		//as well as all params required by the specified tool(s)
-		const totalSteps: Array<Step> = props.completeSetup
-			? [...defaultSteps]
-			: [];
+		const totalSteps: Array<Step> = showOpenAiSetup() ? [...defaultSteps] : [];
 		props.tools.forEach((tool, index) => {
 			const expectedParams = tool.getExpectedParams();
 			if (expectedParams.length != 0) {

--- a/src/Setup.tsx
+++ b/src/Setup.tsx
@@ -2,6 +2,8 @@ import { Link, Typography } from "@mui/material";
 import { Stack } from "@mui/system";
 import { Tool } from "./tools/base/Tool";
 import { ParamsSetup } from "./ParamsSetup";
+import { AltInfo } from "./AltInfo";
+import DeveloperBoardIcon from "@mui/icons-material/DeveloperBoard";
 
 interface SetupProps {
 	completeSetup: Function;
@@ -10,13 +12,19 @@ interface SetupProps {
 	applyToolParams: Function;
 }
 
+const windowAiText = `Instead of specifying an OpenAI key, you can also use the window.ai browser extension to use any model of your choosing! 
+Please refresh this page after installing the extension.`;
+const windowAiTextAlt = `You're using the window.ai browser extension!
+toolformer-zero will use whichever model you have chosen.`;
+const windowAiLink = "https://windowai.io";
+
 export function Setup(props: SetupProps) {
 	return (
 		<Stack spacing={2}>
 			<Typography whiteSpace={"pre-line"} variant="body2">
 				{`Welcome to Toolformer Zero!
                 
-                To start, you'll need to input a couple of API keys in order for model and search APIs to work.`}
+                To start, you'll need to follow a couple of steps in order for LLM and search APIs to work.`}
 			</Typography>
 			<Typography
 				whiteSpace={"pre-line"}
@@ -24,7 +32,7 @@ export function Setup(props: SetupProps) {
 				variant="body2"
 			>
 				{`Your keys will only be used locally, and stored via browser cookie!
-                No requests will be made other than those to OpenAI and Google Search APIs.`}
+                No requests will be made other than those to selected models and tools.`}
 			</Typography>
 
 			<Typography whiteSpace={"pre-line"} variant="body2">
@@ -36,6 +44,11 @@ export function Setup(props: SetupProps) {
 					{"here."}
 				</Link>
 			</Typography>
+			<AltInfo
+				text={(window as any).ai ? windowAiTextAlt : windowAiText}
+				link={windowAiLink}
+				icon={<DeveloperBoardIcon />}
+			></AltInfo>
 			<ParamsSetup {...props}></ParamsSetup>
 		</Stack>
 	);

--- a/src/Setup.tsx
+++ b/src/Setup.tsx
@@ -12,7 +12,7 @@ interface SetupProps {
 	applyToolParams: Function;
 }
 
-const windowAiText = `Instead of specifying an OpenAI key, you can also use the window.ai browser extension to use any model of your choosing! 
+const windowAiText = `Instead of specifying an OpenAI key, you can also install the window.ai browser extension to use any model of your choosing! 
 Please refresh this page after installing the extension.`;
 const windowAiTextAlt = `You're using the window.ai browser extension!
 toolformer-zero will use whichever model you have chosen.`;

--- a/src/WindowAiInfo.tsx
+++ b/src/WindowAiInfo.tsx
@@ -8,17 +8,13 @@ import {
 } from "@mui/material";
 import { useEffect, useRef, useState } from "react";
 import { Stack } from "@mui/system";
-import { Tool } from "./tools/base/Tool";
 import { primaryColor } from "./Constants";
 import CheckIcon from "@mui/icons-material/Check";
-import { ParamsSetup } from "./ParamsSetup";
-import { addActiveTool, isToolActive, removeActiveTool } from "./Cookies";
 import {
 	toolInfoContainerStyle,
 	toolInfoBodyStyle,
 	toolInfoExamplesStyle,
 } from "./MuiStyles";
-import { CorsInfo } from "./CorsInfo";
 
 interface InfoProps {
 	showErrorToast: Function;


### PR DESCRIPTION
- Adapt initial setup to only show OpenAI step if window.ai extension is not found
  - If found, automatically set window.ai setting to true
  - Add google search API key check next to OpenAI key check as minimum conditionals to skip setup
- Add `AltInfo` component